### PR TITLE
Fix Neptune 3 Pro fan pins

### DIFF
--- a/Neptune 3 Pro config/printer.cfg
+++ b/Neptune 3 Pro config/printer.cfg
@@ -108,12 +108,12 @@ pid_ki = 0.723
 pid_kd = 1425.905
 
 [heater_fan hotend_fan]
-pin: PA7
+pin: PB0
 heater: extruder
 heater_temp: 50.0
 
 [fan]
-pin: PB0
+pin: PA7
 
 [force_move]
 enable_force_move: True


### PR DESCRIPTION
They were swapped on my machine, hotend fan controlled the part cooling fans, and vice versa. This fixes it. 