### PR TITLE
Add probe XY offset values for Neptune 3 Pro

### DIFF
--- a/Neptune 3 Pro config/printer.cfg
+++ b/Neptune 3 Pro config/printer.cfg
@@ -127,6 +127,8 @@ pin: ^PA8
 speed: 5
 lift_speed: 15
 samples: 1
+x_offset: -28
+y_offset: 21
 # Calibrate probe: https://www.klipper3d.org/Bed_Level.html
 # - Example: PROBE_CALIBRATE, then adjust with TESTZ Z=+/-X
 #z_offset = -0.100


### PR DESCRIPTION
Measured them on my device, values are within 1.5mm from default marlin values