### PR TITLE
Update printer.cfg

### DIFF
--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Plus/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Plus/printer.cfg
@@ -12,6 +12,8 @@
 #[include timelapse.cfg]
 
 [exclude_object]
+# must be disabled for Sonic Pad
+
 [virtual_sdcard]
 path: ~/gcode_files
 
@@ -193,7 +195,7 @@ pin: PA7
 enable_force_move: True
 
 [safe_z_home]
-home_xy_position: 117.5, 117.5
+home_xy_position: 160, 160
 z_hop: 10
 
 [probe]
@@ -212,15 +214,28 @@ pause_on_runout: true
 switch_pin: PB4
 
 [bed_mesh]
-speed: 300
-horizontal_move_z: 5.0
-mesh_min: 30,30
-mesh_max: 205,205
-probe_count: 6,6
+speed: 200
+horizontal_move_z: 5
+mesh_min: 22,22
+mesh_max: 290,315
+probe_count: 7,7
+fade_start: 1.0
+fade_end: 10.0
 algorithm: bicubic
-fade_start: 1
-fade_end: 10
-fade_target: 0
+
+[screws_tilt_adjust]
+screw1: 65, 13
+screw1_name: left front screw
+screw2: 65, 145
+screw2_name: left middle screw
+screw3: 65, 280
+screw3_name: left back screw
+screw4: 318, 13
+screw4_name: right front screw
+screw5: 318, 145
+screw5_name: right middle screw
+screw6: 318, 280
+screw6_name: right back screw
 
 [input_shaper]
 # Calibrate IS: https://www.klipper3d.org/Resonance_Compensation.html
@@ -252,12 +267,6 @@ gcode:
   G28
   BED_MESH_CALIBRATE
   DATA_SAVE
-  
-[screws_tilt_adjust]
-screw1: 40, 40
-screw2: 40, 230
-screw3: 230, 40
-screw4: 230, 230
 
 #*# <---------------------- SAVE_CONFIG ---------------------->
 #*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.


### PR DESCRIPTION
Changes for the bigger bed of the Plus compared to the Pro and 6 instead 4 screws for the print bed added in the config.

safe_z_hame, bed_mesh and sscrews_tilt_adjust edited.  screws_tilt_adjust also moved below bed_mesh because I think it makes more sense to have it before the gcode_macros at the bottom.

I think it would be a good idea to move all gcode_macros to the bottom of the file to have them separated from the printer config but I didn't want to change the whole file.

Also added a comment for [exclude_object]
It must be disabled for Sonic Pad.