### PR TITLE
Update printer.cfg for Max

### DIFF
--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
@@ -82,6 +82,14 @@ gcode:
       {action_respond_info("Extruder not hot enough")}
     {% endif %}  
     RESUME_BASE {get_params}
+    
+[gcode_macro MANUAL_LEVEL]
+description: Home and measure for maunual leveling adjustments
+gcode:
+  G28
+  SCREWS_TILT_CALCULATE
+  G90
+  G1 F3000 X213 Y213 Z25 
 
 [mcu]
 serial: /dev/ttyUSB0
@@ -115,10 +123,9 @@ enable_pin: !PD2
 microsteps: 16
 rotation_distance: 40
 endstop_pin: PA13
-position_endstop: -6.0
-position_min: -6
-position_max: 420
-homing_speed: 50
+position_endstop: 0
+position_max: 427
+homing_speed: 100
 
 [stepper_y]
 step_pin: PC11
@@ -127,8 +134,9 @@ enable_pin: !PC10
 microsteps: 16
 rotation_distance: 40
 endstop_pin: PB8
-position_endstop: 0
-position_max: 420
+position_endstop: -7
+position_min: -7
+position_max: 427
 homing_speed: 50
 
 [stepper_z]
@@ -138,9 +146,10 @@ enable_pin: !PC8
 rotation_distance: 8
 microsteps: 16
 position_min: -2
-position_max: 500
+position_max: 510
 endstop_pin: probe:z_virtual_endstop # Use Z- as endstop
-homing_speed: 5.0
+homing_speed: 10
+homing_retract_speed: 15
 
 
 [extruder]
@@ -193,14 +202,15 @@ pin: PA7
 enable_force_move: True
 
 [safe_z_home]
-home_xy_position: 210,210
+speed: 100.0
+home_xy_position: 241, 193
 z_hop: 10
 
 [probe]
 pin: ^PA8
 speed: 5
 lift_speed: 15
-samples: 1
+samples: 3
 x_offset: -28
 y_offset: 20
 # Calibrate probe: https://www.klipper3d.org/Bed_Level.html
@@ -212,15 +222,14 @@ pause_on_runout: true
 switch_pin: PB4
 
 [bed_mesh]
-speed: 300
-horizontal_move_z: 5.0
-mesh_min: 30,30
-mesh_max: 380,380
-probe_count: 6,6
-algorithm: bicubic
-fade_start: 1
-fade_end: 10
-fade_target: 0
+probe_count = 10,10
+algorithm = bicubic
+speed: 200
+horizontal_move_z: 10
+mesh_min: 5, 13
+mesh_max: 399, 421
+fade_start: 1.0
+fade_end: 10.0
 
 [input_shaper]
 # Calibrate IS: https://www.klipper3d.org/Resonance_Compensation.html
@@ -254,10 +263,22 @@ gcode:
   DATA_SAVE
   
 [screws_tilt_adjust]
-screw1: 40, 40
-screw2: 40, 330
-screw3: 330, 40
-screw4: 330, 330
+screw_thread: CW-M3
+speed: 200
+screw1: 241, 193
+screw1_name: center
+screw2: 419, 371
+screw2_name: right back screw
+screw3: 419, 193
+screw3_name: right middle screw
+screw4: 419, 15
+screw4_name: right front screw
+screw5: 63, 15
+screw5_name: left front screw
+screw6: 63, 193
+screw6_name: left middle screw
+screw7: 63, 371
+screw7_name: left back screw
 
 #*# <---------------------- SAVE_CONFIG ---------------------->
 #*# DO NOT EDIT THIS BLOCK OR BELOW. The contents are auto-generated.


### PR DESCRIPTION
Pulled from my working Max config. Corrected XY end stops, added proper center point, leveling screw locations with macro, limits, and the most complete bed mesh possible with the stock probe location. Can set printer size to 426x426x500 in slicer.