### PR TITLE
Match values from official Elegoo Marlin sources

### DIFF
--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
@@ -212,8 +212,8 @@ pin: ^PA8
 speed: 5
 lift_speed: 15
 samples: 3
-x_offset: -28
-y_offset: 20
+x_offset: -28.5
+y_offset: 22
 # Calibrate probe: https://www.klipper3d.org/Bed_Level.html
 # - Example: PROBE_CALIBRATE, then adjust with TESTZ Z=+/-X
 z_offset = 1.75

--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
@@ -223,12 +223,12 @@ pause_on_runout: true
 switch_pin: PB4
 
 [bed_mesh]
-probe_count = 10,10
+probe_count = 9,7
 algorithm = bicubic
 speed: 200
 horizontal_move_z: 10
-mesh_min: 5, 13
-mesh_max: 399, 421
+mesh_min: 33, 16
+mesh_max: 397, 415
 fade_start: 1.0
 fade_end: 10.0
 

--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
@@ -269,19 +269,19 @@ gcode:
 [screws_tilt_adjust]
 screw_thread: CW-M3
 speed: 200
-screw1: 241, 193
+screw1: 243.5, 193
 screw1_name: center
-screw2: 419, 371
+screw2: 421, 370.5
 screw2_name: right back screw
-screw3: 419, 193
+screw3: 421, 193
 screw3_name: right middle screw
-screw4: 419, 15
+screw4: 421, 15.5
 screw4_name: right front screw
-screw5: 63, 15
+screw5: 66, 15.5
 screw5_name: left front screw
-screw6: 63, 193
+screw6: 66, 193
 screw6_name: left middle screw
-screw7: 63, 371
+screw7: 66, 370.5
 screw7_name: left back screw
 
 #*# <---------------------- SAVE_CONFIG ---------------------->

--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
@@ -124,7 +124,8 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: PA13
 position_endstop: 0
-position_max: 427
+position_min: 0
+position_max: 430
 homing_speed: 100
 
 [stepper_y]
@@ -134,9 +135,9 @@ enable_pin: !PC10
 microsteps: 16
 rotation_distance: 40
 endstop_pin: PB8
-position_endstop: -7
-position_min: -7
-position_max: 427
+position_endstop: -6
+position_min: -6
+position_max: 430
 homing_speed: 50
 
 [stepper_z]
@@ -145,8 +146,8 @@ dir_pin: !PC9
 enable_pin: !PC8
 rotation_distance: 8
 microsteps: 16
-position_min: -2
-position_max: 510
+position_min: 0
+position_max: 506
 endstop_pin: probe:z_virtual_endstop # Use Z- as endstop
 homing_speed: 10
 homing_retract_speed: 15

--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Plus/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Plus/printer.cfg
@@ -225,17 +225,17 @@ fade_end: 10.0
 algorithm: bicubic
 
 [screws_tilt_adjust]
-screw1: 65, 13
+screw1: 66, 10.5
 screw1_name: left front screw
-screw2: 65, 145
+screw2: 66, 143
 screw2_name: left middle screw
-screw3: 65, 280
+screw3: 66, 270.5
 screw3_name: left back screw
-screw4: 318, 13
+screw4: 321, 10.5
 screw4_name: right front screw
-screw5: 318, 145
+screw5: 321, 143
 screw5_name: right middle screw
-screw6: 318, 280
+screw6: 321, 270.5
 screw6_name: right back screw
 
 [input_shaper]

--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Plus/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Plus/printer.cfg
@@ -204,8 +204,8 @@ pin: ^PA8
 speed: 5
 lift_speed: 15
 samples: 1
-x_offset: -28
-y_offset: 20
+x_offset: -28.5
+y_offset: 22
 # Calibrate probe: https://www.klipper3d.org/Bed_Level.html
 # - Example: PROBE_CALIBRATE, then adjust with TESTZ Z=+/-X
 #z_offset = -0.100

--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Plus/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Plus/printer.cfg
@@ -118,8 +118,8 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: PA13
 position_endstop: -6.0
-position_min: -6
-position_max: 320
+position_min: -8.3
+position_max: 330
 homing_speed: 50
 
 [stepper_y]
@@ -130,7 +130,8 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: PB8
 position_endstop: 0
-position_max: 320
+position_min: -1.3
+position_max: 330
 homing_speed: 50
 
 [stepper_z]
@@ -139,8 +140,8 @@ dir_pin: !PC9
 enable_pin: !PC8
 rotation_distance: 8
 microsteps: 16
-position_min: -2
-position_max: 400
+position_min: 0
+position_max: 410
 endstop_pin: probe:z_virtual_endstop # Use Z- as endstop
 homing_speed: 5.0
 

--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Pro/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Pro/printer.cfg
@@ -116,7 +116,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: PA13
 position_endstop: -6.0
-position_min: -6
+position_min: -5
 position_max: 235
 homing_speed: 50
 
@@ -128,7 +128,8 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: PB8
 position_endstop: 0
-position_max: 235
+position_min: 0
+position_max: 234
 homing_speed: 50
 
 [stepper_z]
@@ -137,8 +138,8 @@ dir_pin: !PC9
 enable_pin: !PC8
 rotation_distance: 8
 microsteps: 16
-position_min: -2
-position_max: 280
+position_min: 0
+position_max: 283
 endstop_pin: probe:z_virtual_endstop # Use Z- as endstop
 homing_speed: 5.0
 

--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Pro/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Pro/printer.cfg
@@ -202,8 +202,8 @@ pin: ^PA8
 speed: 5
 lift_speed: 15
 samples: 1
-x_offset: -28
-y_offset: 20
+x_offset: -28.5
+y_offset: 22
 # Calibrate probe: https://www.klipper3d.org/Bed_Level.html
 # - Example: PROBE_CALIBRATE, then adjust with TESTZ Z=+/-X
 #z_offset = -0.100


### PR DESCRIPTION
For the Neptune 3 Pro, Plus, and Max printer configuration files, a number of values related to the steppers, probe offset, screw tilt adjust, and bed mesh differ from the values in the official Elegoo Marlin source. These values can be changed to better match printer physical dimensions and the behavior observed when using the official Elegoo Marlin firmware.

1. Stepper value changes allow the configurations to better match the physical dimensions of printer bed, end stops, and axes
2. Probe offset value changes allow the configurations to better match the physical dimensions of the toolhead and probe
3. Screw tilt adjust value changes allow the configurations to better match the manual bed leveling behavior observed with the official firmware. This is a subjective change, but might better match users' expectations surrounding a default Klipper configuration replicating the previous Marlin behavior.
4. Bed mesh value changes allow the configurations to better match the automatic bed leveling behavior observed with the official firmware. This is a subjective change, but might better match users' expectations surrounding a default Klipper configuration replicating the previous Marlin behavior.

Closes #29 