### PR TITLE
fix endstop less than min error

### DIFF
--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Pro/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Pro/printer.cfg
@@ -115,7 +115,7 @@ enable_pin: !PD2
 microsteps: 16
 rotation_distance: 40
 endstop_pin: PA13
-position_endstop: -6.0
+position_endstop: -5.0
 position_min: -5
 position_max: 235
 homing_speed: 50


### PR DESCRIPTION
Stepper_x endstop was less than min in the Neptune 3 Pro printer.cfg, causing a fatal error.
Setting position_endstop to match position_min (-5.0) fixes the error.