### PR TITLE
Revert recent Neptune 3 Pro printer.cfg changes

### DIFF
--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Pro/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Pro/printer.cfg
@@ -116,7 +116,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: PA13
 position_endstop: -6.0
-position_min: -5
+position_min: -6
 position_max: 235
 homing_speed: 50
 
@@ -128,8 +128,7 @@ microsteps: 16
 rotation_distance: 40
 endstop_pin: PB8
 position_endstop: 0
-position_min: 0
-position_max: 234
+position_max: 235
 homing_speed: 50
 
 [stepper_z]
@@ -138,8 +137,8 @@ dir_pin: !PC9
 enable_pin: !PC8
 rotation_distance: 8
 microsteps: 16
-position_min: 0
-position_max: 283
+position_min: -2
+position_max: 280
 endstop_pin: probe:z_virtual_endstop # Use Z- as endstop
 homing_speed: 5.0
 
@@ -202,8 +201,8 @@ pin: ^PA8
 speed: 5
 lift_speed: 15
 samples: 1
-x_offset: -28.5
-y_offset: 22
+x_offset: -28
+y_offset: 20
 # Calibrate probe: https://www.klipper3d.org/Bed_Level.html
 # - Example: PROBE_CALIBRATE, then adjust with TESTZ Z=+/-X
 #z_offset = -0.100


### PR DESCRIPTION
Recent changes to Neptune 3 Pro printer.cfg, specifically the one raising the [stepper_z] position_min from -2 to 0, made it impossible for the nozzle to go low enough to perform the paper test, effectively breaking the PROBE_CALIBRATE process.  I reverted the values in my printer.cfg to the original values and the problems went away.

This PR changes the Neptune 3 Pro `printer.cfg` file back to its original values prior to the changes a few days ago in #30 .  

Unless there were complaints about the previous values, you may want to consider reverting the other changes made in that PR as well and request verification that the new proposed values do not create any issues.