### PR TITLE
Decrease max_velocity for N3 Max

### DIFF
--- a/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
+++ b/Neptune 3 Pro, Plus, Max/Neptune 3 Max/printer.cfg
@@ -107,7 +107,7 @@ initial_white: 1.0
 
 [printer]
 kinematics: cartesian
-max_velocity: 500
+max_velocity: 300
 max_accel: 3700
 max_z_velocity: 15
 max_z_accel: 100


### PR DESCRIPTION
The max velocity of 500 mm/min is quite fast for the larger bed of the Neptune 3 Max. For large movements, the belt was skipping and losing accurate position info. Perhaps this could be avoided by just tightening the belt a bit more.